### PR TITLE
Refresh access token during sensor startup

### DIFF
--- a/custom_components/hildebrandglow/config_flow.py
+++ b/custom_components/hildebrandglow/config_flow.py
@@ -14,7 +14,7 @@ DATA_SCHEMA = vol.Schema({"app_id": str, "username": str, "password": str})
 
 
 def config_object(data: dict, glow: Dict[str, Any]) -> Dict[str, Any]:
-    """Prepare a ConfigEntity with authentication data and a temporary token"""
+    """Prepare a ConfigEntity with authentication data and a temporary token."""
     return {
         "name": glow["name"],
         "app_id": data["app_id"],

--- a/custom_components/hildebrandglow/config_flow.py
+++ b/custom_components/hildebrandglow/config_flow.py
@@ -13,14 +13,8 @@ _LOGGER = logging.getLogger(__name__)
 DATA_SCHEMA = vol.Schema({"app_id": str, "username": str, "password": str})
 
 
-async def validate_input(hass: core.HomeAssistant, data: dict) -> Dict[str, Any]:
-    """Validate the user input allows us to connect.
-
-    Data has the keys from DATA_SCHEMA with values provided by the user.
-    """
-    glow = await Glow.authenticate(data["app_id"], data["username"], data["password"])
-
-    # Return some info we want to store in the config entry.
+def config_object(data: dict, glow: Dict[str, Any]) -> Dict[str, Any]:
+    """Prepare a ConfigEntity with authentication data and a temporary token"""
     return {
         "name": glow["name"],
         "app_id": data["app_id"],
@@ -29,6 +23,19 @@ async def validate_input(hass: core.HomeAssistant, data: dict) -> Dict[str, Any]
         "token": glow["token"],
         "token_exp": glow["exp"],
     }
+
+
+async def validate_input(hass: core.HomeAssistant, data: dict) -> Dict[str, Any]:
+    """Validate the user input allows us to connect.
+
+    Data has the keys from DATA_SCHEMA with values provided by the user.
+    """
+    glow = await hass.async_add_executor_job(
+        Glow.authenticate, data["app_id"], data["username"], data["password"]
+    )
+
+    # Return some info we want to store in the config entry.
+    return config_object(data, glow)
 
 
 class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/custom_components/hildebrandglow/glow.py
+++ b/custom_components/hildebrandglow/glow.py
@@ -17,9 +17,7 @@ class Glow:
         self.token = token
 
     @classmethod
-    async def authenticate(
-        cls, app_id: str, username: str, password: str
-    ) -> Dict[str, Any]:
+    def authenticate(cls, app_id: str, username: str, password: str) -> Dict[str, Any]:
         """
         Attempt to authenticate with Glowmarkt.
 
@@ -42,7 +40,7 @@ class Glow:
             pprint(data)
             raise InvalidAuth
 
-    async def retrieve_resources(self) -> List[Dict[str, Any]]:
+    def retrieve_resources(self) -> List[Dict[str, Any]]:
         """Retrieve the resources known to Glowmarkt for the authenticated user."""
         url = f"{self.BASE_URL}/resource"
         headers = {"applicationId": self.app_id, "token": self.token}
@@ -58,7 +56,7 @@ class Glow:
         data = response.json()
         return data
 
-    async def current_usage(self, resource: Dict[str, Any]) -> Dict[str, Any]:
+    def current_usage(self, resource: Dict[str, Any]) -> Dict[str, Any]:
         """Retrieve the current usage for a specified resource."""
         url = f"{self.BASE_URL}/resource/{resource}/current"
         headers = {"applicationId": self.app_id, "token": self.token}

--- a/custom_components/hildebrandglow/sensor.py
+++ b/custom_components/hildebrandglow/sensor.py
@@ -40,7 +40,10 @@ async def async_setup_entry(
         try:
             resources = await hass.async_add_executor_job(glow.retrieve_resources)
         except InvalidAuth:
-            await handle_failed_auth(config, hass)
+            try:
+                await handle_failed_auth(config, hass)
+            except InvalidAuth:
+                return False
 
             glow = hass.data[DOMAIN][entry]
             resources = await hass.async_add_executor_job(glow.retrieve_resources)
@@ -63,6 +66,8 @@ class GlowConsumptionCurrent(Entity):
         "ea02304a-2820-4ea0-8399-f1d1b430c3a0",  # Smart Meter, electricity consumption
         "672b8071-44ff-4f23-bca2-f50c6a3ddd02",  # Smart Meter, gas consumption
     ]
+
+    available = True
 
     def __init__(self, glow: Glow, resource: Dict[str, Any]):
         """Initialize the sensor."""
@@ -135,4 +140,5 @@ class GlowConsumptionCurrent(Entity):
             )
         except InvalidAuth:
             # TODO: Trip the failed auth logic above somehow
+            self.available = False
             pass

--- a/custom_components/hildebrandglow/sensor.py
+++ b/custom_components/hildebrandglow/sensor.py
@@ -34,7 +34,7 @@ async def async_setup_entry(
     for entry in hass.data[DOMAIN]:
         glow = hass.data[DOMAIN][entry]
 
-        resources = dict()
+        resources: dict = dict()
 
         try:
             resources = await hass.async_add_executor_job(glow.retrieve_resources)
@@ -128,7 +128,6 @@ class GlowConsumptionCurrent(Entity):
 
         This is the only method that should fetch new data for Home Assistant.
         """
-
         try:
             self._state = await self.hass.async_add_executor_job(
                 self.glow.current_usage, self.resource["resourceId"]

--- a/custom_components/hildebrandglow/sensor.py
+++ b/custom_components/hildebrandglow/sensor.py
@@ -25,7 +25,8 @@ async def async_setup_entry(
             config.data["password"],
         )
 
-        new_config = config_object(config.data, glow_auth)
+        current_config = dict(config.data.copy())
+        new_config = config_object(current_config, glow_auth)
         hass.config_entries.async_update_entry(entry=config, data=new_config)
 
         glow = Glow(config.data["app_id"], glow_auth["token"])


### PR DESCRIPTION
This PR closes #2 and partially fulfils #1.

There are three main changes in this PR:
- glow.py is no longer flagged as async capable
- Calls to glow.py are wrapped in [hass' async helper](https://developers.home-assistant.io/docs/asyncio_working_with_async/#calling-sync-functions-from-async)
- Sensor setup can detect & recover from expired access tokens

Unfortunately, this still requires the user to restart hass or otherwise reload the component, so there's a bit more work to be done on #1.