### PR TITLE
Create hassfest.yaml

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,0 +1,14 @@
+name: Validate with hassfest
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  validate:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v2"
+      - uses: home-assistant/actions/hassfest@master

--- a/custom_components/hildebrandglow/strings.json
+++ b/custom_components/hildebrandglow/strings.json
@@ -1,6 +1,6 @@
 {
+  "title": "Hildebrand Glow",
   "config": {
-    "title": "Hildebrand Glow",
     "step": {
       "user": {
         "title": "Hildebrand Glow API access",

--- a/custom_components/hildebrandglow/translations/en.json
+++ b/custom_components/hildebrandglow/translations/en.json
@@ -17,7 +17,7 @@
                 },
                 "title": "Hildebrand Glow API access"
             }
-        },
-        "title": "Hildebrand Glow"
-    }
+        }
+    },
+    "title": "Hildebrand Glow"
 }


### PR DESCRIPTION
This PR enables the [hassfest GitHub Action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) for this project to ensure the codebase is linted against upcoming changes to Home Assistant.