### PR TITLE
Migrate to MQTT from HTTPS polling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.8"
+  - "3.9"
 install:
   # Attempt to work around Home Assistant not being declared through PEP 561
   # Details: https://github.com/home-assistant/core/pull/28866#pullrequestreview-319309922

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
+# Archived
+This repository was archived on 30 April 2022 (see https://github.com/unlobito/ha-hildebrandglow/discussions/55 for details).
+
+[HandyHat/ha-hildebrandglow-dcc](https://github.com/HandyHat/ha-hildebrandglow-dcc) is maintained as a fork for DCC users.
+
 # ha-hildebrandglow
+
 HomeAssistant integration for the [Hildebrand Glow](https://www.hildebrand.co.uk/our-products/) smart meter HAN for UK SMETS meters.
 
 You'll need to have an active Glow account (usable through the Bright app), [a Consumer Access Device](https://www.hildebrand.co.uk/our-products/), and MQTT access enabled before using this integration. If you haven't been given MQTT connection details by Hildebrand, you'll need to contact them and request MQTT access be enabled for your account.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ha-hildebrandglow
 HomeAssistant integration for the [Hildebrand Glow](https://www.hildebrand.co.uk/our-products/) smart meter HAN for UK SMETS meters.
 
-Before using this integration, you'll need to have an active Glow account (usable through the Bright app) and API access enabled. If you haven't been given an API Application ID by Hildebrand, you'll need to contact them and request API access be enabled for your account.
+You'll need to have an active Glow account (usable through the Bright app), [a Consumer Access Device](https://www.hildebrand.co.uk/our-products/), and MQTT access enabled before using this integration. If you haven't been given MQTT connection details by Hildebrand, you'll need to contact them and request MQTT access be enabled for your account.
 
 This integration will currently emit one sensor for the current usage of each detected smart meter.
 

--- a/custom_components/hildebrandglow/__init__.py
+++ b/custom_components/hildebrandglow/__init__.py
@@ -6,7 +6,7 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
+from .const import APP_ID, DOMAIN
 from .glow import Glow
 
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
@@ -23,7 +23,7 @@ async def async_setup(hass: HomeAssistant, config: Dict[str, Any]) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Hildebrand Glow from a config entry."""
-    glow = Glow(entry.data["app_id"], entry.data["token"])
+    glow = Glow(APP_ID, entry.data["token"])
     hass.data[DOMAIN][entry.entry_id] = glow
 
     for component in PLATFORMS:

--- a/custom_components/hildebrandglow/__init__.py
+++ b/custom_components/hildebrandglow/__init__.py
@@ -6,10 +6,8 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .config_flow import config_object
 from .const import APP_ID, DOMAIN
 from .glow import Glow, InvalidAuth
-from .sensor import GlowConsumptionCurrent
 
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
 
@@ -23,38 +21,18 @@ async def async_setup(hass: HomeAssistant, config: Dict[str, Any]) -> bool:
     return True
 
 
-async def handle_failed_auth(config: ConfigEntry, hass: HomeAssistant) -> None:
-    """Attempt to refresh the current Glow token."""
-    glow_auth = await hass.async_add_executor_job(
-        Glow.authenticate,
-        APP_ID,
-        config.data["username"],
-        config.data["password"],
-    )
-
-    current_config = dict(config.data.copy())
-    new_config = config_object(current_config, glow_auth)
-    hass.config_entries.async_update_entry(entry=config, data=new_config)
-
-    glow = Glow(APP_ID, glow_auth["token"])
-    hass.data[DOMAIN][config.entry_id] = glow
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Hildebrand Glow from a config entry."""
-    glow = Glow(APP_ID, entry.data["token"])
+    glow = Glow(APP_ID, entry.data["username"], entry.data["password"])
 
     try:
+        await hass.async_add_executor_job(glow.authenticate)
         await hass.async_add_executor_job(glow.retrieve_cad_hardwareId)
-        resources = await hass.async_create_task(glow.connect_mqtt())
+        await hass.async_create_task(glow.connect_mqtt())
         hass.async_create_task(glow.retrieve_mqtt())
 
     except InvalidAuth:
-        try:
-            await handle_failed_auth(entry, hass)
-            return False
-        except InvalidAuth:
-            return False
+        return False
 
     hass.data[DOMAIN][entry.entry_id] = glow
 

--- a/custom_components/hildebrandglow/__init__.py
+++ b/custom_components/hildebrandglow/__init__.py
@@ -40,9 +40,35 @@ async def handle_failed_auth(config: ConfigEntry, hass: HomeAssistant) -> None:
     hass.data[DOMAIN][config.entry_id] = glow
 
 
+async def retrieve_cad_hardwareId(hass: HomeAssistant, glow: Glow) -> str:
+    """Locate the Consumer Access Device's hardware ID from the devices list."""
+    ZIGBEE_GLOW_STICK = "1027b6e8-9bfd-4dcb-8068-c73f6413cfaf"
+
+    devices = await hass.async_add_executor_job(glow.retrieve_devices)
+
+    cad: Dict[str, Any] = next(
+        (dev for dev in devices if dev["deviceTypeId"] == ZIGBEE_GLOW_STICK), None
+    )
+
+    return cad["hardwareId"]
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Hildebrand Glow from a config entry."""
     glow = Glow(APP_ID, entry.data["token"])
+
+    try:
+        hardwareId: str = await retrieve_cad_hardwareId(hass, glow)
+        mqtt_topic: str = f"SMART/HILD/{hardwareId}"
+
+        resources = await hass.async_add_executor_job(glow.retrieve_resources)
+
+    except InvalidAuth:
+        try:
+            await handle_failed_auth(entry, hass)
+            return False
+        except InvalidAuth:
+            return False
+
     hass.data[DOMAIN][entry.entry_id] = glow
 
     for component in PLATFORMS:

--- a/custom_components/hildebrandglow/__init__.py
+++ b/custom_components/hildebrandglow/__init__.py
@@ -28,8 +28,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     try:
         await hass.async_add_executor_job(glow.authenticate)
         await hass.async_add_executor_job(glow.retrieve_cad_hardwareId)
-        await hass.async_create_task(glow.connect_mqtt())
-        hass.async_create_task(glow.retrieve_mqtt())
+        await hass.async_add_executor_job(glow.connect_mqtt)
+
+        while not glow.broker_active:
+            continue
 
     except InvalidAuth:
         return False

--- a/custom_components/hildebrandglow/__init__.py
+++ b/custom_components/hildebrandglow/__init__.py
@@ -6,8 +6,10 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
+from .config_flow import config_object
 from .const import APP_ID, DOMAIN
-from .glow import Glow
+from .glow import Glow, InvalidAuth
+from .sensor import GlowConsumptionCurrent
 
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
 
@@ -19,6 +21,23 @@ async def async_setup(hass: HomeAssistant, config: Dict[str, Any]) -> bool:
     hass.data[DOMAIN] = {}
 
     return True
+
+
+async def handle_failed_auth(config: ConfigEntry, hass: HomeAssistant) -> None:
+    """Attempt to refresh the current Glow token."""
+    glow_auth = await hass.async_add_executor_job(
+        Glow.authenticate,
+        APP_ID,
+        config.data["username"],
+        config.data["password"],
+    )
+
+    current_config = dict(config.data.copy())
+    new_config = config_object(current_config, glow_auth)
+    hass.config_entries.async_update_entry(entry=config, data=new_config)
+
+    glow = Glow(APP_ID, glow_auth["token"])
+    hass.data[DOMAIN][config.entry_id] = glow
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/hildebrandglow/__init__.py
+++ b/custom_components/hildebrandglow/__init__.py
@@ -40,27 +40,14 @@ async def handle_failed_auth(config: ConfigEntry, hass: HomeAssistant) -> None:
     hass.data[DOMAIN][config.entry_id] = glow
 
 
-async def retrieve_cad_hardwareId(hass: HomeAssistant, glow: Glow) -> str:
-    """Locate the Consumer Access Device's hardware ID from the devices list."""
-    ZIGBEE_GLOW_STICK = "1027b6e8-9bfd-4dcb-8068-c73f6413cfaf"
-
-    devices = await hass.async_add_executor_job(glow.retrieve_devices)
-
-    cad: Dict[str, Any] = next(
-        (dev for dev in devices if dev["deviceTypeId"] == ZIGBEE_GLOW_STICK), None
-    )
-
-    return cad["hardwareId"]
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Hildebrand Glow from a config entry."""
     glow = Glow(APP_ID, entry.data["token"])
 
     try:
-        hardwareId: str = await retrieve_cad_hardwareId(hass, glow)
-        mqtt_topic: str = f"SMART/HILD/{hardwareId}"
-
-        resources = await hass.async_add_executor_job(glow.retrieve_resources)
+        await hass.async_add_executor_job(glow.retrieve_cad_hardwareId)
+        resources = await hass.async_create_task(glow.connect_mqtt())
+        hass.async_create_task(glow.retrieve_mqtt())
 
     except InvalidAuth:
         try:

--- a/custom_components/hildebrandglow/__init__.py
+++ b/custom_components/hildebrandglow/__init__.py
@@ -1,20 +1,24 @@
 """The Hildebrand Glow integration."""
 import asyncio
-import logging
 from typing import Any, Dict
 
+import async_timeout
 import voluptuous as vol
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
+    InvalidStateError,
+)
 
-from .const import APP_ID, DOMAIN
-from .glow import Glow, InvalidAuth, NoCADAvailable
-
-_LOGGER = logging.getLogger(__name__)
+from .const import APP_ID, DOMAIN, GLOW_SESSION, LOGGER
+from .glow import CannotConnect, Glow, InvalidAuth, NoCADAvailable
 
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
 
-PLATFORMS = ["sensor"]
+PLATFORMS = (SENSOR_DOMAIN,)
 
 
 async def async_setup(hass: HomeAssistant, config: Dict[str, Any]) -> bool:
@@ -26,47 +30,74 @@ async def async_setup(hass: HomeAssistant, config: Dict[str, Any]) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Hildebrand Glow from a config entry."""
-    glow = Glow(APP_ID, entry.data["username"], entry.data["password"])
+    glow = Glow(
+        APP_ID,
+        entry.data["username"],
+        entry.data["password"],
+    )
 
     try:
-        await hass.async_add_executor_job(glow.authenticate)
-        await hass.async_add_executor_job(glow.retrieve_cad_hardwareId)
-        await hass.async_add_executor_job(glow.connect_mqtt)
+        if not await async_connect_or_timeout(hass, glow):
+            return False
+    except CannotConnect as err:
+        raise ConfigEntryNotReady from err
 
-        while not glow.broker_active:
-            continue
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = {GLOW_SESSION: glow}
 
-    except InvalidAuth:
-        _LOGGER.error("Couldn't login with the provided username/password.")
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
-        return False
-
-    except NoCADAvailable:
-        _LOGGER.error("Couldn't find any CAD devices (e.g. Glow Stick)")
-
-        return False
-
-    hass.data[DOMAIN][entry.entry_id] = glow
-
-    for component in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, component)
-        )
+    if not entry.update_listeners:
+        entry.add_update_listener(async_update_options)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload a config entry."""
-    unload_ok = all(
-        await asyncio.gather(
-            *[
-                hass.config_entries.async_forward_entry_unload(entry, component)
-                for component in PLATFORMS
-            ]
-        )
-    )
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
+async def async_connect_or_timeout(hass: HomeAssistant, glow: Glow) -> bool:
+    """Connect from Glow."""
+    try:
+        async with async_timeout.timeout(10):
+            LOGGER.debug("Initialize connection from Glow")
 
+            await hass.async_add_executor_job(glow.authenticate)
+            await hass.async_add_executor_job(glow.retrieve_cad_hardwareId)
+            await hass.async_add_executor_job(glow.connect_mqtt)
+
+            while not glow.broker_active:
+                await asyncio.sleep(1)
+    except InvalidAuth as err:
+        LOGGER.error("Couldn't login with the provided username/password")
+        raise ConfigEntryAuthFailed from err
+
+    except NoCADAvailable as err:
+        LOGGER.error("Couldn't find any CAD devices (e.g. Glow Stick)")
+        raise InvalidStateError from err
+
+    except asyncio.TimeoutError as err:
+        await async_disconnect_or_timeout(hass, glow)
+        LOGGER.debug("Timeout expired: %s", err)
+        raise CannotConnect from err
+
+    return True
+
+
+async def async_disconnect_or_timeout(hass: HomeAssistant, glow: Glow) -> bool:
+    """Disconnect from Glow."""
+    LOGGER.debug("Disconnect from Glow")
+    async with async_timeout.timeout(3):
+        await hass.async_add_executor_job(glow.disconnect)
+    return True
+
+
+async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Update options."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload Hildebrand Glow config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        coordinator = hass.data[DOMAIN].pop(entry.entry_id)
+        await coordinator[GLOW_SESSION].disconnect()
     return unload_ok

--- a/custom_components/hildebrandglow/__init__.py
+++ b/custom_components/hildebrandglow/__init__.py
@@ -1,5 +1,6 @@
 """The Hildebrand Glow integration."""
 import asyncio
+import logging
 from typing import Any, Dict
 
 import voluptuous as vol
@@ -7,7 +8,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .const import APP_ID, DOMAIN
-from .glow import Glow, InvalidAuth
+from .glow import Glow, InvalidAuth, NoCADAvailable
+
+_LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
 
@@ -34,6 +37,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             continue
 
     except InvalidAuth:
+        _LOGGER.error("Couldn't login with the provided username/password.")
+
+        return False
+
+    except NoCADAvailable:
+        _LOGGER.error("Couldn't find any CAD devices (e.g. Glow Stick)")
+
         return False
 
     hass.data[DOMAIN][entry.entry_id] = glow

--- a/custom_components/hildebrandglow/config_flow.py
+++ b/custom_components/hildebrandglow/config_flow.py
@@ -1,4 +1,6 @@
 """Config flow for Hildebrand Glow integration."""
+from __future__ import annotations
+
 import logging
 from typing import Any, Dict
 
@@ -19,8 +21,6 @@ def config_object(data: dict, glow: Dict[str, Any]) -> Dict[str, Any]:
         "name": glow["name"],
         "username": data["username"],
         "password": data["password"],
-        "token": glow["token"],
-        "token_exp": glow["exp"],
     }
 
 
@@ -29,12 +29,12 @@ async def validate_input(hass: core.HomeAssistant, data: dict) -> Dict[str, Any]
 
     Data has the keys from DATA_SCHEMA with values provided by the user.
     """
-    glow = await hass.async_add_executor_job(
-        Glow.authenticate, APP_ID, data["username"], data["password"]
-    )
+    glow = Glow(APP_ID, data["username"], data["password"])
+
+    auth_data: Dict[str, Any] = await hass.async_add_executor_job(glow.authenticate)
 
     # Return some info we want to store in the config entry.
-    return config_object(data, glow)
+    return config_object(data, auth_data)
 
 
 class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -44,7 +44,7 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     CONNECTION_CLASS = config_entries.SOURCE_USER
 
     async def async_step_user(
-        self, user_input: Dict = None
+        self, user_input: dict[str, Any] | None = None
     ) -> data_entry_flow.FlowResult:
         """Handle the initial step."""
         errors = {}

--- a/custom_components/hildebrandglow/config_flow.py
+++ b/custom_components/hildebrandglow/config_flow.py
@@ -5,19 +5,18 @@ from typing import Any, Dict
 import voluptuous as vol
 from homeassistant import config_entries, core
 
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import APP_ID, DOMAIN  # pylint:disable=unused-import
 from .glow import CannotConnect, Glow, InvalidAuth
 
 _LOGGER = logging.getLogger(__name__)
 
-DATA_SCHEMA = vol.Schema({"app_id": str, "username": str, "password": str})
+DATA_SCHEMA = vol.Schema({"username": str, "password": str})
 
 
 def config_object(data: dict, glow: Dict[str, Any]) -> Dict[str, Any]:
     """Prepare a ConfigEntity with authentication data and a temporary token."""
     return {
         "name": glow["name"],
-        "app_id": data["app_id"],
         "username": data["username"],
         "password": data["password"],
         "token": glow["token"],
@@ -31,7 +30,7 @@ async def validate_input(hass: core.HomeAssistant, data: dict) -> Dict[str, Any]
     Data has the keys from DATA_SCHEMA with values provided by the user.
     """
     glow = await hass.async_add_executor_job(
-        Glow.authenticate, data["app_id"], data["username"], data["password"]
+        Glow.authenticate, APP_ID, data["username"], data["password"]
     )
 
     # Return some info we want to store in the config entry.

--- a/custom_components/hildebrandglow/const.py
+++ b/custom_components/hildebrandglow/const.py
@@ -1,3 +1,4 @@
 """Constants for the Hildebrand Glow integration."""
 
 DOMAIN = "hildebrandglow"
+APP_ID = "b0f1b774-a586-4f72-9edd-27ead8aa7a8d"

--- a/custom_components/hildebrandglow/const.py
+++ b/custom_components/hildebrandglow/const.py
@@ -1,4 +1,10 @@
 """Constants for the Hildebrand Glow integration."""
+import logging
+from typing import Final
 
-DOMAIN = "hildebrandglow"
-APP_ID = "b0f1b774-a586-4f72-9edd-27ead8aa7a8d"
+DOMAIN: Final = "hildebrandglow"
+APP_ID: Final = "b0f1b774-a586-4f72-9edd-27ead8aa7a8d"
+
+LOGGER = logging.getLogger(__package__)
+
+GLOW_SESSION: Final = "glow_session"

--- a/custom_components/hildebrandglow/glow.py
+++ b/custom_components/hildebrandglow/glow.py
@@ -19,8 +19,7 @@ class Glow:
 
     BASE_URL = "https://api.glowmarkt.com/api/v0-1"
     HILDEBRAND_MQTT_HOST = "glowmqtt.energyhive.com"
-    HILDEBRAND_MQTT_TOPIC = "SMART/HILD/{hardwareId}"
-    HILDEBRAND_MQTT_LEGACY = "SMART/DCAD/{hardwareId}"
+    HILDEBRAND_MQTT_TOPIC = "SMART/+/{hardwareId}"
 
     username: str
     password: str
@@ -106,13 +105,7 @@ class Glow:
     ) -> None:
         """Receive a CONNACK message from the server."""
         client.subscribe(
-            [
-                (self.HILDEBRAND_MQTT_TOPIC.format(hardwareId=self.hardwareId), 0),
-                (
-                    self.HILDEBRAND_MQTT_LEGACY.format(hardwareId=self.hardwareId),
-                    0,
-                ),
-            ]
+            [(self.HILDEBRAND_MQTT_TOPIC.format(hardwareId=self.hardwareId), 0)]
         )
 
         self.broker_active = True

--- a/custom_components/hildebrandglow/glow.py
+++ b/custom_components/hildebrandglow/glow.py
@@ -27,7 +27,7 @@ class Glow:
     token: str
 
     hardwareId: str
-    broker: mqtt
+    broker: mqtt.Client
 
     sensors: Dict[str, GlowConsumptionCurrent] = {}
 
@@ -111,8 +111,6 @@ class Glow:
 
     def _cb_on_message(self, client, userdata, msg):
         """Receive a PUBLISH message from the server."""
-        print(msg.topic + " " + str(msg.payload))
-
         payload = MQTTPayload(msg.payload)
 
         if "electricity.consumption" in self.sensors:

--- a/custom_components/hildebrandglow/glow.py
+++ b/custom_components/hildebrandglow/glow.py
@@ -40,6 +40,22 @@ class Glow:
             pprint(data)
             raise InvalidAuth
 
+    def retrieve_devices(self) -> List[Dict[str, Any]]:
+        """Retrieve the Zigbee devices known to Glowmarkt for the authenticated user."""
+        url = f"{self.BASE_URL}/device"
+        headers = {"applicationId": self.app_id, "token": self.token}
+
+        try:
+            response = requests.get(url, headers=headers)
+        except requests.Timeout:
+            raise CannotConnect
+
+        if response.status_code != 200:
+            raise InvalidAuth
+
+        data = response.json()
+        return data
+
     def retrieve_resources(self) -> List[Dict[str, Any]]:
         """Retrieve the resources known to Glowmarkt for the authenticated user."""
         url = f"{self.BASE_URL}/resource"

--- a/custom_components/hildebrandglow/glow.py
+++ b/custom_components/hildebrandglow/glow.py
@@ -83,11 +83,18 @@ class Glow:
     def retrieve_cad_hardwareId(self) -> str:
         """Locate the Consumer Access Device's hardware ID from the devices list."""
         ZIGBEE_GLOW_STICK = "1027b6e8-9bfd-4dcb-8068-c73f6413cfaf"
+        ZIGBEE_GLOW_DISPLAY_SMETS2 = "b91cf82f-aafe-47f4-930a-b2ed1c7b2691"
 
         devices = self.retrieve_devices()
 
         cad: Dict[str, Any] = next(
-            (dev for dev in devices if dev["deviceTypeId"] == ZIGBEE_GLOW_STICK), {}
+            (
+                dev
+                for dev in devices
+                if dev["deviceTypeId"]
+                in [ZIGBEE_GLOW_STICK, ZIGBEE_GLOW_DISPLAY_SMETS2]
+            ),
+            {},
         )
 
         self.hardwareId = cad["hardwareId"]

--- a/custom_components/hildebrandglow/glow.py
+++ b/custom_components/hildebrandglow/glow.py
@@ -116,6 +116,9 @@ class Glow:
         if "electricity.consumption" in self.sensors:
             self.sensors["electricity.consumption"].update_state(payload)
 
+        if "gas.consumption" in self.sensors:
+            self.sensors["gas.consumption"].update_state(payload)
+
     def retrieve_resources(self) -> List[Dict[str, Any]]:
         """Retrieve the resources known to Glowmarkt for the authenticated user."""
         url = f"{self.BASE_URL}/resource"

--- a/custom_components/hildebrandglow/glow.py
+++ b/custom_components/hildebrandglow/glow.py
@@ -5,11 +5,17 @@ from typing import Any, Dict, List
 import requests
 from homeassistant import exceptions
 
+from hbmqtt.client import MQTTClient
+from hbmqtt.mqtt.constants import QOS_1
+
 
 class Glow:
     """Bindings for the Hildebrand Glow Platform API."""
 
     BASE_URL = "https://api.glowmarkt.com/api/v0-1"
+
+    hardwareId: str
+    broker: MQTTClient
 
     def __init__(self, app_id: str, token: str):
         """Create an authenticated Glow object."""
@@ -55,6 +61,46 @@ class Glow:
 
         data = response.json()
         return data
+
+    def retrieve_cad_hardwareId(self) -> str:
+        """Locate the Consumer Access Device's hardware ID from the devices list."""
+        ZIGBEE_GLOW_STICK = "1027b6e8-9bfd-4dcb-8068-c73f6413cfaf"
+
+        devices = self.retrieve_devices()
+
+        cad: Dict[str, Any] = next(
+            (dev for dev in devices if dev["deviceTypeId"] == ZIGBEE_GLOW_STICK), None
+        )
+
+        self.hardwareId = cad["hardwareId"]
+
+        return self.hardwareId
+
+    async def connect_mqtt(self) -> None:
+        """Connect the internal MQTT client to the discovered CAD"""
+        HILDEBRAND_MQTT_HOST = (
+            "mqtts://USER:PASS@glowmqtt.energyhive.com/"
+        )
+        HILDEBRAND_MQTT_TOPIC = "SMART/HILD/{hardwareId}"
+
+        cad_hwId = self.hardwareId
+        topic = HILDEBRAND_MQTT_TOPIC.format(hardwareId=cad_hwId)
+
+        self.broker = MQTTClient()
+
+        await self.broker.connect(HILDEBRAND_MQTT_HOST)
+
+        await self.broker.subscribe(
+            [
+                (topic, QOS_1),
+            ]
+        )
+
+    async def retrieve_mqtt(self) -> None:
+        while True:
+            message = await self.broker.deliver_message()
+            packet = message.publish_packet.payload.data.decode()
+            print(packet)
 
     def retrieve_resources(self) -> List[Dict[str, Any]]:
         """Retrieve the resources known to Glowmarkt for the authenticated user."""

--- a/custom_components/hildebrandglow/glow.py
+++ b/custom_components/hildebrandglow/glow.py
@@ -20,6 +20,7 @@ class Glow:
     BASE_URL = "https://api.glowmarkt.com/api/v0-1"
     HILDEBRAND_MQTT_HOST = "glowmqtt.energyhive.com"
     HILDEBRAND_MQTT_TOPIC = "SMART/HILD/{hardwareId}"
+    HILDEBRAND_MQTT_LEGACY = "SMART/DCAD/{hardwareId}"
 
     username: str
     password: str
@@ -101,7 +102,15 @@ class Glow:
 
     def _cb_on_connect(self, client, userdata, flags, rc):
         """Receive a CONNACK message from the server."""
-        client.subscribe(self.HILDEBRAND_MQTT_TOPIC.format(hardwareId=self.hardwareId))
+        client.subscribe(
+            [
+                (self.HILDEBRAND_MQTT_TOPIC.format(hardwareId=self.hardwareId), 0),
+                (
+                    self.HILDEBRAND_MQTT_LEGACY.format(hardwareId=self.hardwareId),
+                    0,
+                ),
+            ]
+        )
 
         self.broker_active = True
 

--- a/custom_components/hildebrandglow/glow.py
+++ b/custom_components/hildebrandglow/glow.py
@@ -97,9 +97,12 @@ class Glow:
             {},
         )
 
-        self.hardwareId = cad["hardwareId"]
+        if "hardwareId" in cad:
+            self.hardwareId = cad["hardwareId"]
 
-        return self.hardwareId
+            return self.hardwareId
+        else:
+            raise NoCADAvailable
 
     def connect_mqtt(self) -> None:
         """Connect the internal MQTT client to the discovered CAD."""
@@ -178,3 +181,7 @@ class CannotConnect(exceptions.HomeAssistantError):
 
 class InvalidAuth(exceptions.HomeAssistantError):
     """Error to indicate there is invalid auth."""
+
+
+class NoCADAvailable(exceptions.HomeAssistantError):
+    """Error to indicate no CADs were found."""

--- a/custom_components/hildebrandglow/glow/glowdata.py
+++ b/custom_components/hildebrandglow/glow/glowdata.py
@@ -1,0 +1,44 @@
+"""Data classes for interpreted Glow structures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from . import MQTTPayload
+
+
+@dataclass
+class SmartMeter:
+    """Data object for platform agnostic smart metering information."""
+
+    gas_consumption: float | None
+
+    power_consumption: int | None
+    energy_consumption: float | None
+
+    @staticmethod
+    def from_mqtt_payload(data: MQTTPayload) -> SmartMeter:
+        """Populate SmartMeter object from an MQTTPayload object."""
+        meter = SmartMeter(
+            gas_consumption=None,
+            power_consumption=None,
+            energy_consumption=None,
+        )
+
+        if data.gas:
+            ahc = data.gas.alternative_historical_consumption
+            meter.gas_consumption = ahc.current_day_consumption_delivered
+
+        if data.electricity:
+            meter.power_consumption = (
+                data.electricity.historical_consumption.instantaneous_demand
+            )
+
+            if data.electricity.reading_information_set.current_summation_delivered:
+                meter.energy_consumption = (
+                    data.electricity.reading_information_set.current_summation_delivered
+                    * data.electricity.formatting.multiplier
+                    / data.electricity.formatting.divisor
+                )
+
+        return meter

--- a/custom_components/hildebrandglow/glow/mqttpayload.py
+++ b/custom_components/hildebrandglow/glow/mqttpayload.py
@@ -93,10 +93,10 @@ class Meter:
         unit_of_measure: Optional[UnitofMeasure]
         """Unit for the measured value."""
 
-        multiplier: Optional[int]
+        multiplier: int
         """Multiplier value for smart meter readings."""
 
-        divisor: Optional[int]
+        divisor: int
         """Divisor value for smart meter readings."""
 
         summation_formatting: Optional[str]
@@ -122,8 +122,8 @@ class Meter:
             formatting = payload["0702"]["03"] if "03" in payload["0702"] else {}
 
             self.unit_of_measure = self.UnitofMeasure(formatting.get("00", "00"))
-            self.multiplier = int(formatting["01"], 16) if "01" in formatting else None
-            self.divisor = int(formatting["02"], 16) if "02" in formatting else None
+            self.multiplier = int(formatting["01"], 16) if "01" in formatting else 1
+            self.divisor = int(formatting["02"], 16) if "02" in formatting else 1
             self.summation_formatting = formatting.get("03")
             self.demand_formatting = formatting.get("04")
             self.metering_device_type = (

--- a/custom_components/hildebrandglow/manifest.json
+++ b/custom_components/hildebrandglow/manifest.json
@@ -3,7 +3,7 @@
   "name": "Hildebrand Glow",
   "config_flow": true,
   "documentation": "https://github.com/unlobito/ha-hildebrandglow",
-  "requirements": ["requests", "amqtt"],
+  "requirements": ["requests", "paho-mqtt"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/custom_components/hildebrandglow/manifest.json
+++ b/custom_components/hildebrandglow/manifest.json
@@ -3,12 +3,10 @@
   "name": "Hildebrand Glow",
   "config_flow": true,
   "documentation": "https://github.com/unlobito/ha-hildebrandglow",
-  "requirements": ["requests"],
+  "requirements": ["requests", "amqtt"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},
   "dependencies": [],
-  "codeowners": [
-    "@unlobito"
-  ]
+  "codeowners": ["@unlobito"]
 }

--- a/custom_components/hildebrandglow/manifest.json
+++ b/custom_components/hildebrandglow/manifest.json
@@ -8,5 +8,7 @@
   "zeroconf": [],
   "homekit": {},
   "dependencies": [],
-  "codeowners": ["@unlobito"]
+  "codeowners": ["@unlobito"],
+  "iot_class": "cloud_polling",
+  "version": "0.1.1"
 }

--- a/custom_components/hildebrandglow/mqttpayload.py
+++ b/custom_components/hildebrandglow/mqttpayload.py
@@ -1,7 +1,7 @@
 """Helper classes for Zigbee Smart Energy Profile data."""
 import json
 from enum import Enum
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 
 class Meter:
@@ -17,19 +17,19 @@ class Meter:
             ARMED = "01"
             ON = "02"
 
-        current_summation_delivered: int
+        current_summation_delivered: Optional[int]
         """Import energy usage"""
 
-        current_summation_received: int
+        current_summation_received: Optional[int]
         """Export energy usage"""
 
-        current_max_demand_delivered: int
+        current_max_demand_delivered: Optional[int]
         """Maximum import energy usage rate"""
 
-        reading_snapshot_time: str
+        reading_snapshot_time: Optional[int]
         """Last time all of the reported attributed were updated"""
 
-        supply_status: SupplyStatus
+        supply_status: Optional[SupplyStatus]
         """Current state of the meter's supply."""
 
         def __init__(self, payload: Dict[str, Any]):
@@ -65,7 +65,7 @@ class Meter:
     class MeterStatus:
         """Information about the meter's error conditions."""
 
-        status: str
+        status: Optional[str]
         """Meter error conditions"""
 
         def __init__(self, payload: Dict[str, Any]):
@@ -89,31 +89,31 @@ class Meter:
             ELECTRIC = "00"
             GAS = "80"
 
-        unit_of_measure: UnitofMeasure
+        unit_of_measure: Optional[UnitofMeasure]
         """Unit for the measured value."""
 
-        multiplier: int
+        multiplier: Optional[int]
         """Multiplier value for smart meter readings."""
 
-        divisor: int
+        divisor: Optional[int]
         """Divisor value for smart meter readings."""
 
-        summation_formatting: str
+        summation_formatting: Optional[str]
         """Bitmap representing decimal places in Summation readings."""
 
-        demand_formatting: str
+        demand_formatting: Optional[str]
         """Bitmap representing decimal places in Demand readings."""
 
-        metering_device_type: MeteringDeviceType
+        metering_device_type: Optional[MeteringDeviceType]
         """Smart meter device type."""
 
-        siteID: str
+        siteID: Optional[str]
         """Electricicity MPAN / Gas MPRN."""
 
-        meter_serial_number: str
+        meter_serial_number: Optional[str]
         """Smart meter serial number."""
 
-        alternative_unit_of_measure: UnitofMeasure
+        alternative_unit_of_measure: Optional[UnitofMeasure]
         """Alternative unit for the measured value."""
 
         def __init__(self, payload: Dict[str, Any]):
@@ -139,16 +139,16 @@ class Meter:
     class HistoricalConsumption:
         """Information about the meter's historical readings."""
 
-        instantaneous_demand: int
+        instantaneous_demand: Optional[int]
         """Instantaneous import energy usage rate"""
 
-        current_day_consumption_delivered: int
+        current_day_consumption_delivered: Optional[int]
         """Import energy used in the current day."""
 
-        current_week_consumption_delivered: int
+        current_week_consumption_delivered: Optional[int]
         """Import energy used in the current week."""
 
-        current_month_consumption_delivered: int
+        current_month_consumption_delivered: Optional[int]
         """Import energy used in the current month."""
 
         def __init__(self, payload: Dict[str, Any]):
@@ -181,13 +181,13 @@ class Meter:
     class AlternativeHistoricalConsumption:
         """Information about the meter's altenative historical readings."""
 
-        current_day_consumption_delivered: int
+        current_day_consumption_delivered: Optional[int]
         """Import energy used in the current day."""
 
-        current_week_consumption_delivered: int
+        current_week_consumption_delivered: Optional[int]
         """Import energy used in the current week."""
 
-        current_month_consumption_delivered: int
+        current_month_consumption_delivered: Optional[int]
         """Import energy used in the current month."""
 
         def __init__(self, payload: Dict[str, Any]):
@@ -232,15 +232,15 @@ class Meter:
 class MQTTPayload:
     """Object representing a payload received over MQTT."""
 
-    electricity: Meter
+    electricity: Optional[Meter]
     """Data interpreted from an electricity meter."""
 
-    gas: Meter
+    gas: Optional[Meter]
     """Data interpreted from a gas meter."""
 
-    def __init__(self, payload: str):
+    def __init__(self, input: str):
         """Create internal Meter instances based off the unprocessed payload."""
-        payload = json.loads(payload)
+        payload: Dict[str, Any] = json.loads(input)
         self.electricity = (
             Meter(payload["elecMtr"]) if "03" in payload["elecMtr"]["0702"] else None
         )

--- a/custom_components/hildebrandglow/mqttpayload.py
+++ b/custom_components/hildebrandglow/mqttpayload.py
@@ -1,37 +1,159 @@
 import json
+from enum import Enum
 from typing import Any, Dict
 
 
 class Meter:
+    class ReadingInformationSet:
+        current_summation_delivered: int
+        current_summation_received: int
+        current_max_demand_delivered: int
+        reading_snapshot_time: str
+        supply_status: int
+
+        def __init__(self, payload: Dict[str, Any]):
+            reading_information_set = (
+                payload["0702"]["00"] if "00" in payload["0702"] else {}
+            )
+
+            self.current_summation_delivered = (
+                int(reading_information_set["00"], 16)
+                if "00" in reading_information_set
+                else None
+            )
+            self.current_summation_received = (
+                int(reading_information_set["01"], 16)
+                if "01" in reading_information_set
+                else None
+            )
+            self.current_max_demand_delivered = (
+                int(reading_information_set["02"], 16)
+                if "02" in reading_information_set
+                else None
+            )
+            self.reading_snapshot_time = (
+                int(reading_information_set["07"], 16)
+                if "07" in reading_information_set
+                else None
+            )
+            self.supply_status = (
+                int(reading_information_set["07"], 16)
+                if "07" in reading_information_set
+                else None
+            )
+
+    class MeterStatus:
+        status: str
+
+        def __init__(self, payload: Dict[str, Any]):
+            meter_status = payload["0702"]["02"] if "02" in payload["0702"] else {}
+
+            self.status = meter_status.get("00")
+
+    class Formatting:
+        class UnitofMeasure(Enum):
+            KWH = "00"
+            M3 = "01"
+
+        class MeteringDeviceType(Enum):
+            ELECTRIC = "00"
+            GAS = "80"
+
+        unit_of_measure: UnitofMeasure
+        multiplier: int
+        divisor: int
+        summation_formatting: str
+        demand_formatting: str
+        metering_device_type: MeteringDeviceType
+        siteID: str
+        meter_serial_number: str
+        alternative_unit_of_measure: UnitofMeasure
+
+        def __init__(self, payload: Dict[str, Any]):
+            formatting = payload["0702"]["03"] if "03" in payload["0702"] else {}
+
+            self.unit_of_measure = self.UnitofMeasure(formatting.get("00", "00"))
+            self.multiplier = int(formatting["01"], 16) if "01" in formatting else None
+            self.divisor = int(formatting["02"], 16) if "02" in formatting else None
+            self.summation_formatting = formatting.get("03")
+            self.demand_formatting = formatting.get("04")
+            self.metering_device_type = (
+                self.MeteringDeviceType(formatting["06"])
+                if "06" in formatting
+                else None
+            )
+            self.siteID = formatting.get("07")
+            self.meter_serial_number = formatting.get("08")
+            self.alternative_unit_of_measure = (
+                self.UnitofMeasure(formatting["12"]) if "12" in formatting else None
+            )
+
+    class HistoricalConsumption:
+        instantaneous_demand: int
+        current_day_consumption_delivered: int
+        current_week_consumption_delivered: int
+        current_month_consumption_delivered: int
+
+        def __init__(self, payload: Dict[str, Any]):
+            historical_consumption = (
+                payload["0702"]["04"] if "04" in payload["0702"] else {}
+            )
+
+            self.instantaneous_demand = (
+                int(historical_consumption["00"], 16)
+                if "00" in historical_consumption
+                else None
+            )
+            self.current_day_consumption_delivered = (
+                int(historical_consumption["01"], 16)
+                if "01" in historical_consumption
+                else None
+            )
+            self.current_week_consumption_delivered = (
+                int(historical_consumption["30"], 16)
+                if "30" in historical_consumption
+                else None
+            )
+            self.current_week_consumption_delivered = (
+                int(historical_consumption["40"], 16)
+                if "40" in historical_consumption
+                else None
+            )
+
+    class AlternativeHistoricalConsumption:
+        current_day_consumption_delivered: int
+        current_week_consumption_delivered: int
+        current_month_consumption_delivered: int
+
+        def __init__(self, payload: Dict[str, Any]):
+            alternative_historical_consumption = (
+                payload["0702"]["0C"] if "0C" in payload["0702"] else {}
+            )
+
+            self.current_day_consumption_delivered = (
+                int(alternative_historical_consumption["01"], 16)
+                if "01" in alternative_historical_consumption
+                else None
+            )
+            self.current_week_consumption_delivered = (
+                int(alternative_historical_consumption["30"], 16)
+                if "30" in alternative_historical_consumption
+                else None
+            )
+            self.current_week_consumption_delivered = (
+                int(alternative_historical_consumption["40"], 16)
+                if "40" in alternative_historical_consumption
+                else None
+            )
+
     def __init__(self, payload: Dict[str, Any]):
-        historical_consumption = (
-            payload["0702"]["04"] if "04" in payload["0702"] else {}
+        self.reading_information_set = self.ReadingInformationSet(payload)
+        self.meter_status = self.MeterStatus(payload)
+        self.formatting = self.Formatting(payload)
+        self.historical_consumption = self.HistoricalConsumption(payload)
+        self.alternative_historical_consumption = self.AlternativeHistoricalConsumption(
+            payload
         )
-
-        self.consumption = (
-            int(historical_consumption["00"], 16)
-            if "00" in historical_consumption
-            else None
-        )
-        self.daily_consumption = (
-            int(historical_consumption["01"], 16)
-            if "01" in historical_consumption
-            else None
-        )
-        self.weekly_consumption = (
-            int(historical_consumption["30"], 16)
-            if "30" in historical_consumption
-            else None
-        )
-        self.monthly_consumption = (
-            int(historical_consumption["40"], 16)
-            if "40" in historical_consumption
-            else None
-        )
-
-        formatting = payload["0702"]["03"] if "03" in payload["0702"] else {}
-        self.multiplier = int(formatting["01"], 16) if "01" in formatting else None
-        self.divisor = int(formatting["02"], 16) if "02" in formatting else None
 
         self.meter = (
             int(payload["0702"]["00"]["00"], 16)
@@ -41,9 +163,14 @@ class Meter:
 
 
 class MQTTPayload:
-    payload: Dict[str, Any]
+    electricity: Meter
+    gas: Meter
 
     def __init__(self, payload: str):
-        self.payload = json.loads(payload)
-        self.electricity = Meter(self.payload["elecMtr"])
-        self.gas = Meter(self.payload["gasMtr"])
+        payload = json.loads(payload)
+        self.electricity = (
+            Meter(payload["elecMtr"]) if "03" in payload["elecMtr"]["0702"] else None
+        )
+        self.gas = (
+            Meter(payload["gasMtr"]) if "03" in payload["gasMtr"]["0702"] else None
+        )

--- a/custom_components/hildebrandglow/mqttpayload.py
+++ b/custom_components/hildebrandglow/mqttpayload.py
@@ -59,7 +59,7 @@ class Meter:
                 else None
             )
             self.supply_status = self.SupplyStatus(
-                reading_information_set.get("07", "00")
+                reading_information_set.get("14", "00")
             )
 
     class MeterStatus:

--- a/custom_components/hildebrandglow/mqttpayload.py
+++ b/custom_components/hildebrandglow/mqttpayload.py
@@ -1,0 +1,49 @@
+import json
+from typing import Any, Dict
+
+
+class Meter:
+    def __init__(self, payload: Dict[str, Any]):
+        historical_consumption = (
+            payload["0702"]["04"] if "04" in payload["0702"] else {}
+        )
+
+        self.consumption = (
+            int(historical_consumption["00"], 16)
+            if "00" in historical_consumption
+            else None
+        )
+        self.daily_consumption = (
+            int(historical_consumption["01"], 16)
+            if "01" in historical_consumption
+            else None
+        )
+        self.weekly_consumption = (
+            int(historical_consumption["30"], 16)
+            if "30" in historical_consumption
+            else None
+        )
+        self.monthly_consumption = (
+            int(historical_consumption["40"], 16)
+            if "40" in historical_consumption
+            else None
+        )
+
+        formatting = payload["0702"]["03"] if "03" in payload["0702"] else {}
+        self.multiplier = int(formatting["01"], 16) if "01" in formatting else None
+        self.divisor = int(formatting["02"], 16) if "02" in formatting else None
+
+        self.meter = (
+            int(payload["0702"]["00"]["00"], 16)
+            if "00" in payload["0702"]["00"]
+            else None
+        )
+
+
+class MQTTPayload:
+    payload: Dict[str, Any]
+
+    def __init__(self, payload: str):
+        self.payload = json.loads(payload)
+        self.electricity = Meter(self.payload["elecMtr"])
+        self.gas = Meter(self.payload["gasMtr"])

--- a/custom_components/hildebrandglow/mqttpayload.py
+++ b/custom_components/hildebrandglow/mqttpayload.py
@@ -1,5 +1,6 @@
 """Helper classes for Zigbee Smart Energy Profile data."""
 import json
+import struct
 from enum import Enum
 from typing import Any, Dict, Optional
 
@@ -158,7 +159,7 @@ class Meter:
             )
 
             self.instantaneous_demand = (
-                int(historical_consumption["00"], 16)
+                self._hex_twos_complement_to_decimal(historical_consumption["00"])
                 if "00" in historical_consumption
                 else None
             )
@@ -177,6 +178,10 @@ class Meter:
                 if "40" in historical_consumption
                 else None
             )
+
+        def _hex_twos_complement_to_decimal(self, hex_value: str) -> int:
+            """Perform signed 2's complement conversion."""
+            return int(struct.unpack(">i", bytes.fromhex(hex_value))[0])
 
     class AlternativeHistoricalConsumption:
         """Information about the meter's altenative historical readings."""

--- a/custom_components/hildebrandglow/mqttpayload.py
+++ b/custom_components/hildebrandglow/mqttpayload.py
@@ -181,7 +181,9 @@ class Meter:
 
         def _hex_twos_complement_to_decimal(self, hex_value: str) -> int:
             """Perform signed 2's complement conversion."""
-            return int(struct.unpack(">i", bytes.fromhex(hex_value))[0])
+            if len(hex_value) == 8:
+                return int(struct.unpack(">i", bytes.fromhex(hex_value))[0])
+            return int(hex_value, 16)
 
     class AlternativeHistoricalConsumption:
         """Information about the meter's altenative historical readings."""

--- a/custom_components/hildebrandglow/sensor.py
+++ b/custom_components/hildebrandglow/sensor.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN
 from .glow import Glow, InvalidAuth
-from .mqttpayload import Meter
+from .mqttpayload import Meter, MQTTPayload
 
 
 async def async_setup_entry(
@@ -89,7 +89,7 @@ class GlowConsumptionCurrent(Entity):
         }
 
     @property
-    def state(self) -> Optional[str]:
+    def state(self) -> Optional[int]:
         """Return the state of the sensor."""
         if self._state:
             if self.resource["dataSourceResourceTypeInfo"]["type"] == "ELEC":
@@ -97,10 +97,9 @@ class GlowConsumptionCurrent(Entity):
             elif self.resource["dataSourceResourceTypeInfo"]["type"] == "GAS":
                 alt = self._state.alternative_historical_consumption
                 return alt.current_day_consumption_delivered
-        else:
-            return None
+        return None
 
-    def update_state(self, meter) -> None:
+    def update_state(self, meter: MQTTPayload) -> None:
         """Receive an MQTT update from Glow and update the internal state."""
         self._state = meter.electricity
         self.async_write_ha_state()
@@ -118,5 +117,5 @@ class GlowConsumptionCurrent(Entity):
                 return POWER_WATT
             elif self.resource["dataSourceResourceTypeInfo"]["type"] == "GAS":
                 return VOLUME_CUBIC_METERS
-        else:
-            return None
+
+        return None

--- a/custom_components/hildebrandglow/sensor.py
+++ b/custom_components/hildebrandglow/sensor.py
@@ -6,8 +6,7 @@ from homeassistant.const import DEVICE_CLASS_POWER, POWER_WATT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
 
-from .config_flow import config_object
-from .const import APP_ID, DOMAIN
+from .const import DOMAIN
 from .glow import Glow, InvalidAuth
 
 
@@ -17,8 +16,6 @@ async def async_setup_entry(
     """Set up the sensor platform."""
     new_entities = []
 
-
-
     for entry in hass.data[DOMAIN]:
         glow = hass.data[DOMAIN][entry]
 
@@ -27,13 +24,8 @@ async def async_setup_entry(
         try:
             resources = await hass.async_add_executor_job(glow.retrieve_resources)
         except InvalidAuth:
-            try:
-                await handle_failed_auth(config, hass)
-            except InvalidAuth:
-                return False
+            return False
 
-            glow = hass.data[DOMAIN][entry]
-            resources = await hass.async_add_executor_job(glow.retrieve_resources)
         for resource in resources:
             if resource["classifier"] in GlowConsumptionCurrent.knownClassifiers:
                 sensor = GlowConsumptionCurrent(glow, resource)

--- a/custom_components/hildebrandglow/sensor.py
+++ b/custom_components/hildebrandglow/sensor.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Dict, Optional
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import DEVICE_CLASS_POWER, POWER_WATT, VOLUME_CUBIC_METERS
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity import DeviceInfo, Entity
 
 from .const import DOMAIN
 from .glow import Glow, InvalidAuth
@@ -76,7 +76,7 @@ class GlowConsumptionCurrent(Entity):
             return None
 
     @property
-    def device_info(self) -> Optional[Dict[str, Any]]:
+    def device_info(self) -> Optional[DeviceInfo]:
         """Return information about the sensor data source."""
         if self.resource["dataSourceResourceTypeInfo"]["type"] == "ELEC":
             human_type = "electricity"

--- a/custom_components/hildebrandglow/sensor.py
+++ b/custom_components/hildebrandglow/sensor.py
@@ -7,7 +7,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
 
 from .config_flow import config_object
-from .const import DOMAIN
+from .const import APP_ID, DOMAIN
 from .glow import Glow, InvalidAuth
 
 
@@ -19,17 +19,14 @@ async def async_setup_entry(
 
     async def handle_failed_auth(config: ConfigEntry, hass: HomeAssistant) -> None:
         glow_auth = await hass.async_add_executor_job(
-            Glow.authenticate,
-            config.data["app_id"],
-            config.data["username"],
-            config.data["password"],
+            Glow.authenticate, APP_ID, config.data["username"], config.data["password"],
         )
 
         current_config = dict(config.data.copy())
         new_config = config_object(current_config, glow_auth)
         hass.config_entries.async_update_entry(entry=config, data=new_config)
 
-        glow = Glow(config.data["app_id"], glow_auth["token"])
+        glow = Glow(APP_ID, glow_auth["token"])
         hass.data[DOMAIN][config.entry_id] = glow
 
     for entry in hass.data[DOMAIN]:

--- a/custom_components/hildebrandglow/sensor.py
+++ b/custom_components/hildebrandglow/sensor.py
@@ -45,12 +45,13 @@ class GlowConsumptionCurrent(Entity):
 
     knownClassifiers = ["gas.consumption", "electricity.consumption"]
 
+    _state: Optional[Meter]
     available = True
     should_poll = False
 
     def __init__(self, glow: Glow, resource: Dict[str, Any]):
         """Initialize the sensor."""
-        self._state: Optional[Meter] = None
+        self._state = None
         self.glow = glow
         self.resource = resource
 
@@ -91,7 +92,7 @@ class GlowConsumptionCurrent(Entity):
     def state(self) -> Optional[str]:
         """Return the state of the sensor."""
         if self._state:
-            return self._state.consumption
+            return self._state.historical_consumption.instantaneous_demand
         else:
             return None
 

--- a/custom_components/hildebrandglow/sensor.py
+++ b/custom_components/hildebrandglow/sensor.py
@@ -2,7 +2,7 @@
 from typing import Any, Callable, Dict, Optional
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import DEVICE_CLASS_POWER, POWER_WATT
+from homeassistant.const import DEVICE_CLASS_POWER, POWER_WATT, VOLUME_CUBIC_METERS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
 
@@ -92,7 +92,11 @@ class GlowConsumptionCurrent(Entity):
     def state(self) -> Optional[str]:
         """Return the state of the sensor."""
         if self._state:
-            return self._state.historical_consumption.instantaneous_demand
+            if self.resource["dataSourceResourceTypeInfo"]["type"] == "ELEC":
+                return self._state.historical_consumption.instantaneous_demand
+            elif self.resource["dataSourceResourceTypeInfo"]["type"] == "GAS":
+                alt = self._state.alternative_historical_consumption
+                return alt.current_day_consumption_delivered
         else:
             return None
 
@@ -110,6 +114,9 @@ class GlowConsumptionCurrent(Entity):
     def unit_of_measurement(self) -> Optional[str]:
         """Return the unit of measurement."""
         if self._state is not None:
-            return POWER_WATT
+            if self.resource["dataSourceResourceTypeInfo"]["type"] == "ELEC":
+                return POWER_WATT
+            elif self.resource["dataSourceResourceTypeInfo"]["type"] == "GAS":
+                return VOLUME_CUBIC_METERS
         else:
             return None

--- a/custom_components/hildebrandglow/sensor.py
+++ b/custom_components/hildebrandglow/sensor.py
@@ -29,7 +29,6 @@ SENSORS: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="gas_consumption",
         name="Gas Consumption",
-        entity_registry_enabled_default=False,
         native_unit_of_measurement=VOLUME_CUBIC_METERS,
         device_class=DEVICE_CLASS_GAS,
         state_class=STATE_CLASS_TOTAL_INCREASING,
@@ -99,6 +98,11 @@ class GlowSensorEntity(SensorEntity):
     def on_message(self, message: Any) -> None:
         """Receive callback for incoming MQTT payloads."""
         self.hass.add_job(self.async_write_ha_state)
+
+    @property
+    def available(self) -> bool:
+        """Return the sensor's availability."""
+        return getattr(self.glow.data, self.entity_description.key) is not None
 
     @property
     def native_value(self) -> StateType:

--- a/custom_components/hildebrandglow/sensor.py
+++ b/custom_components/hildebrandglow/sensor.py
@@ -102,7 +102,7 @@ class GlowConsumptionCurrent(Entity):
     def update_state(self, meter: MQTTPayload) -> None:
         """Receive an MQTT update from Glow and update the internal state."""
         self._state = meter.electricity
-        self.async_write_ha_state()
+        self.hass.add_job(self.async_write_ha_state)
 
     @property
     def device_class(self) -> str:

--- a/custom_components/hildebrandglow/strings.json
+++ b/custom_components/hildebrandglow/strings.json
@@ -5,7 +5,6 @@
       "user": {
         "title": "Hildebrand Glow API access",
         "data": {
-          "app_id": "Application ID",
           "username": "Username",
           "password": "Password"
         }

--- a/custom_components/hildebrandglow/translations/en.json
+++ b/custom_components/hildebrandglow/translations/en.json
@@ -11,7 +11,6 @@
         "step": {
             "user": {
                 "data": {
-                    "app_id": "Application ID",
                     "password": "Password",
                     "username": "Username"
                 },

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ black==21.4b0
 flake8==3.9.1
 isort==5.8.0
 mypy==0.812
+amqtt==0.10.0a3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@ black==21.4b0
 flake8==3.9.1
 isort==5.8.0
 mypy==0.812
-amqtt==0.10.0a3
+paho-mqtt==1.5.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,6 @@ black==21.4b0
 flake8==3.9.1
 isort==5.8.0
 mypy==0.812
+pycodestyle==2.7.0
+pyflakes==2.3.1
 paho-mqtt==1.5.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,3 +22,6 @@ ignore_errors = True
 
 [mypy-voluptuous]
 ignore_missing_imports = True
+
+[mypy-paho.*]
+ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,13 +1,9 @@
 [flake8]
-extend-ignore = E203, E231,
 max-line-length = 88
+extend-ignore = E203
 
 [isort]
-combine_as_imports = True
-force_grid_wrap = 0
-include_trailing_comma = True
-line_length = 88
-multi_line_output = 3
+profile = black
 known_third_party = homeassistant,voluptuous
 
 [mypy]


### PR DESCRIPTION
The integration currently uses HTTPS polling to retrieve data from the CAD, but it'd be beneficial to use mqtt for real-time data instead.

This PR will cover implementing this in various stages:
- [x] Use Bright appID rather than public appID (closes #15)
- [x] Extend Glow bindings to implement the `/api/v0-1/device` endpoint for ZigBee device discovery
- [x] Discover the Zigbee Glow Stick hardwareId for MQTT topic setup (SMART/HILD/$hardwareId)
- [x] Migrate HTTPS sensors to MQTT (closes #14)
  - [x] Current electricity usage
  - [x] Last reported gas usage (closes #10)
- [ ] Extend with more sensors from MQTT data (closes #12, #13)
  - [ ] Investigate available data fields
- [~] ~Create services for historical usage reads~