### PR TITLE
Change how entities are discovered

### DIFF
--- a/custom_components/hildebrandglow/sensor.py
+++ b/custom_components/hildebrandglow/sensor.py
@@ -52,7 +52,7 @@ async def async_setup_entry(
                 sensor = GlowConsumptionCurrent(glow, resource)
                 new_entities.append(sensor)
 
-    async_add_entities([sensor])
+        async_add_entities(new_entities)
 
     return True
 

--- a/custom_components/hildebrandglow/sensor.py
+++ b/custom_components/hildebrandglow/sensor.py
@@ -104,7 +104,7 @@ class GlowConsumptionCurrent(Entity):
             human_type = "gas"
 
         return {
-            "identifiers": {(DOMAIN, self.resource["dataSourceUnitInfo"]["shid"])},
+            "identifiers": {(DOMAIN, self.resource["resourceId"])},
             "name": f"Smart Meter, {human_type}",
         }
 


### PR DESCRIPTION
I'm new to your project but tried setting it up with my smart meter. I discovered that it would only add my gas meter and not my electricity meter.

Upon investigation you seem to be using `["dataSourceUnitInfo"]["shid"]` as a UID for the meter. My electricity and gas meter share the `shid` so all sensors would be created against a single device. i.e. I'd see sensor.electricity and sensor.gas appear under "Smart meter, gas". Using `resourceId` solves this for me, creating two meters with sensors attached to them each.

In addition to this, your loop that adds sensors doesnt reference `new_entities` which may be an omission. 

After change: 
![image](https://user-images.githubusercontent.com/870417/94482286-ee6edb80-01d0-11eb-9dc9-7229b56e7f20.png)
![image](https://user-images.githubusercontent.com/870417/94482307-f595e980-01d0-11eb-92d0-3e59a4c4d94e.png)

Before change:
![image](https://user-images.githubusercontent.com/870417/94482481-3ee63900-01d1-11eb-8a3a-e4dad0fb429b.png)
![image](https://user-images.githubusercontent.com/870417/94482504-473e7400-01d1-11eb-9ea5-640723267643.png)
