### PR TITLE
Use classifiers instead of resource type IDs

### DIFF
--- a/custom_components/hildebrandglow/sensor.py
+++ b/custom_components/hildebrandglow/sensor.py
@@ -48,7 +48,7 @@ async def async_setup_entry(
             glow = hass.data[DOMAIN][entry]
             resources = await hass.async_add_executor_job(glow.retrieve_resources)
         for resource in resources:
-            if resource["resourceTypeId"] in GlowConsumptionCurrent.resourceTypeId:
+            if resource["classifier"] in GlowConsumptionCurrent.knownClassifiers:
                 sensor = GlowConsumptionCurrent(glow, resource)
                 new_entities.append(sensor)
 
@@ -62,9 +62,9 @@ class GlowConsumptionCurrent(Entity):
 
     hass: HomeAssistant
 
-    resourceTypeId = [
-        "ea02304a-2820-4ea0-8399-f1d1b430c3a0",  # Smart Meter, electricity consumption
-        "672b8071-44ff-4f23-bca2-f50c6a3ddd02",  # Smart Meter, gas consumption
+    knownClassifiers = [
+        "gas.consumption",
+        "electricity.consumption"
     ]
 
     available = True

--- a/custom_components/hildebrandglow/sensor.py
+++ b/custom_components/hildebrandglow/sensor.py
@@ -62,10 +62,7 @@ class GlowConsumptionCurrent(Entity):
 
     hass: HomeAssistant
 
-    knownClassifiers = [
-        "gas.consumption",
-        "electricity.consumption"
-    ]
+    knownClassifiers = ["gas.consumption", "electricity.consumption"]
 
     available = True
 


### PR DESCRIPTION
Use the resource's classifier instead of the resourceTypeID that appears to differ between suppliers / data collection method. As per https://github.com/unlobito/ha-hildebrandglow/issues/19#issuecomment-782872063 (and the linked documentation). I think this should resolve #19 ?. I realise that this is a stop gap until the project switches over to MQTT but it'd be nice to have it working until that is ready!

It created gas and electricity sensors for CAD data attached to some EDF meters in the UK. Electricity seems to be instantaneous usage and gas is actually the meter reading but I think that is a separate issue :smiley: 